### PR TITLE
[Feat/#42] 강의평가 게시글 검색 기능 구현

### DIFF
--- a/src/main/java/com/example/lectureevaluationdev/controller/evaluation/EvaluationController.java
+++ b/src/main/java/com/example/lectureevaluationdev/controller/evaluation/EvaluationController.java
@@ -38,8 +38,13 @@ public class EvaluationController {
         }
         EvaluationResponse result = evaluationService.writeEvaluation(evaluationDTO);
         return result;
-
-
     }
 
+    @GetMapping("/search")
+    public EvaluationResponse searchEvaluationBoards(@RequestParam("lectureDivide") String lectureDivide,
+                                                     @RequestParam("pageNum") int pageNum,
+                                                     @RequestParam("searchType") String searchType,
+                                                     @RequestParam("search") String search) {
+        return evaluationService.searchEvaluations(lectureDivide, pageNum, searchType, search);
+    }
 }

--- a/src/main/java/com/example/lectureevaluationdev/repository/evaluation/EvaluationRepository.java
+++ b/src/main/java/com/example/lectureevaluationdev/repository/evaluation/EvaluationRepository.java
@@ -1,10 +1,33 @@
 package com.example.lectureevaluationdev.repository.evaluation;
 
 import com.example.lectureevaluationdev.entity.evaluation.EvaluationEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EvaluationRepository extends JpaRepository<EvaluationEntity, Long>, PagingAndSortingRepository<EvaluationEntity,Long> {
+    @Query("SELECT e FROM EvaluationEntity e WHERE (:lectureDivide = '전체' OR e.lectureDivide = :lectureDivide) " +
+            "AND (LOWER(e.lectureName) LIKE %:search% OR LOWER(e.professorName) LIKE %:search% OR LOWER(e.semesterDivide) LIKE %:search% " +
+            "OR LOWER(e.evaluationTitle) LIKE %:search% OR LOWER(e.evaluationContent) LIKE %:search%) " +
+            "ORDER BY e.createdAt DESC")
+    Page<EvaluationEntity> findByLectureDivideAndSearchOrderByCreatedAtDesc(
+            @Param("lectureDivide") String lectureDivide,
+            @Param("search") String search,
+            Pageable pageable
+    );
+
+    @Query("SELECT e FROM EvaluationEntity e WHERE (:lectureDivide = '전체' OR e.lectureDivide = :lectureDivide) " +
+            "AND (LOWER(e.lectureName) LIKE %:search% OR LOWER(e.professorName) LIKE %:search% OR LOWER(e.semesterDivide) LIKE %:search% " +
+            "OR LOWER(e.evaluationTitle) LIKE %:search% OR LOWER(e.evaluationContent) LIKE %:search%) " +
+            "ORDER BY e.likeCount DESC")
+    Page<EvaluationEntity> findByLectureDivideAndSearchOrderByLikeCountDesc(
+            @Param("lectureDivide") String lectureDivide,
+            @Param("search") String search,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/example/lectureevaluationdev/service/evaluation/EvaluationService.java
+++ b/src/main/java/com/example/lectureevaluationdev/service/evaluation/EvaluationService.java
@@ -7,8 +7,16 @@ import com.example.lectureevaluationdev.primary.EvaluationResponse;
 import com.example.lectureevaluationdev.primary.ResponseService;
 import com.example.lectureevaluationdev.repository.evaluation.EvaluationRepository;
 import com.example.lectureevaluationdev.repository.user.UserRepository;
+import io.micrometer.common.util.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class EvaluationService extends ResponseService {
@@ -36,7 +44,54 @@ public class EvaluationService extends ResponseService {
             System.out.println("글 작성 오류 발생");
         }
         return null;
+    }
+
+    public EvaluationResponse searchEvaluations(String lectureDivide, int pageNum, String searchType, String search) {
+        EvaluationResponse.ResponseMap response = new EvaluationResponse.ResponseMap();
+
+        try {
+            int pageSize = 10; // 페이지당 게시물 수
+
+            Sort sort = Sort.by(Sort.Direction.DESC, "createdAt"); // 정렬 기준 설정
+            Pageable pageable = PageRequest.of(pageNum - 1, pageSize, sort);
+
+            Page<EvaluationEntity> evaluationPage;
+
+            if (searchType.equals("최신순")) {
+                if (StringUtils.isNotEmpty(search)) {
+                    evaluationPage = evaluationRepository.findByLectureDivideAndSearchOrderByCreatedAtDesc(lectureDivide, search, pageable);
+                } else {
+                    response.setResponseData("message", "검색어를 입력해주세요.");
+                    return response;
+                }
+            } else if (searchType.equals("추천순")) {
+                if (StringUtils.isNotEmpty(search)) {
+                    evaluationPage = evaluationRepository.findByLectureDivideAndSearchOrderByLikeCountDesc(lectureDivide, search, pageable);
+                } else {
+                    response.setResponseData("message", "검색어를 입력해주세요.");
+                    return response;
+                }
+            } else {
+                response.setResponseData("message", "올바르지 않은 검색 조건입니다.");
+                return response;
+            }
 
 
+            List<EvaluationDTO> evaluationDTOList = new ArrayList<>();
+            for (EvaluationEntity evaluationEntity : evaluationPage.getContent()) {
+                EvaluationDTO evaluationDTO = EvaluationMapper.INSTANCE.toDTO(evaluationEntity);
+                evaluationDTOList.add(evaluationDTO);
+            }
+
+            response.setResponseData("message", "검색 결과를 가져왔습니다.");
+            response.setResponseData("evaluations", evaluationDTOList);
+            response.setResponseData("totalPages", evaluationPage.getTotalPages());
+            return response;
+        } catch (Exception e) {
+            e.printStackTrace();
+            response.setResponseData("message", "검색 도중 오류가 발생했습니다.");
+        }
+
+        return response;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ server.port=8082
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.datasource.username=root
-spring.datasource.password=1234
+spring.datasource.password=juj75077507!@
 
 
 spring.datasource.url=jdbc:mysql://localhost:3306/lectureevaluation?serverTimezone=UTC


### PR DESCRIPTION
## 📌 관련 이슈
  closed #42 

## ✨ 변경 내용
- 강의 평가 게시글 검색 기능 구현

- EvaluationController : searchEvaluationBoards 메서드 추가

- EvaluationRepository : 검색 관련 메서드 추가 (쿼리 이용)

- EvaluationService : searchEvaluations 메서드 추가

- api url : http://localhost:'포트넘버'/evaluation/search?lectureDivide='전공 or 교양 or 전체 or 기타'&searchType='추천순 or 최신순'&search='검색할 단어'&pageNum='검색할 페이지 번호'

- mysql 비밀번호 변경하는 거 또 까먹었어요... ㅜㅜ 죄송함다..


## 📸 스크린샷(선택)
![전공_추천순_1학기_검색](https://github.com/CUK-LikeLion-Common/Evaluation-Lecture-team10/assets/127376237/5b32c795-c22d-4da8-b32d-cddcb1c258e4)
![교양_추천순_test_검색](https://github.com/CUK-LikeLion-Common/Evaluation-Lecture-team10/assets/127376237/af5096e8-1def-4ffd-a5a0-7fba5dfdccfc)
![전공_최신순_박정흠_검색](https://github.com/CUK-LikeLion-Common/Evaluation-Lecture-team10/assets/127376237/5e60dda8-8d3b-45f6-8ee3-3e905d2278af)

순서대로 전공-추천순-1학기 / 교양-추천순-test / 전공-최신순-박정흠 검색


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

